### PR TITLE
Fixed setup port script permissions

### DIFF
--- a/port_setup.sh
+++ b/port_setup.sh
@@ -16,6 +16,7 @@ echo 'sudo parsec << EOF' >> Parsec.sh
 echo 'y\n' >> Parsec.sh
 echo '1\n' >> Parsec.sh
 echo 'EOF' >> Parsec.sh
+chmod a+x Parsec.sh
 echo "Port file written"
 
 if [ "$1" != "-nodrv" ]

--- a/setup.sh
+++ b/setup.sh
@@ -51,6 +51,7 @@ echo 'sudo parsec << EOF' >> Parsec.sh
 echo 'y\n' >> Parsec.sh
 echo '1\n' >> Parsec.sh
 echo 'EOF' >> Parsec.sh
+chmod a+x Parsec.sh
 echo "ROM File written"
 
 if [ "$1" != "-nodrv" ]


### PR DESCRIPTION
After install parsec didn't appear in ports list since the script created didn't have exec permissions.
This fixes the issue.