### PR TITLE
Fix sed command to append parsec_cfg in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,9 @@ rm -rf ~pi/.emulationstation/themes/carbon/parsec
 if [ -e ~pi/.emulationstation/es_systems.cfg ]; then
   # don't want to add it twice
   if ! grep -q '<name>Parsec</name>' ~/.emulationstation/es_systems.cfg; then
-    sed -i '\$e printf "$PARSEC_CFG"' ~/.emulationstation/es_systems.cfg
+    #sed to append: $: match last line; e\ execute printf command; using -i, for in-place, to slap it onto es_systems.cfg
+    #there was a backslash typo in the original of '\$e... that shoudl be '$e\...
+    sed -i '$e\ printf "$PARSEC_CFG"' ~/.emulationstation/es_systems.cfg
     echo "Parsec entry added to EmulationStation in ~pi"
   fi
 fi
@@ -27,7 +29,8 @@ fi
 if [ -e /etc/emulationstation/es_systems.cfg ]; then
   # same as above: don't want to add it twice
   if ! grep -q '<name>Parsec</name>' /etc/emulationstation/es_systems.cfg; then
-    sudo sed -i '\$e printf "$PARSEC_CFG"' /etc/emulationstation/es_systems.cfg
+    #there was a backslash typo in the original of '\$e... that shoudl be '$e\...
+    sudo sed -i '$e\ printf "$PARSEC_CFG"' /etc/emulationstation/es_systems.cfg
     echo "Parsec entry added to EmulationStation in /etc"
   fi
 fi


### PR DESCRIPTION
setup.sh fails because of typo in sed command to append PARSEC_CFG to es_systems.cfg.

Really not sure I fixed it because I have no idea what I'm doing.

Should fix #35 